### PR TITLE
Redirects from /[champName] to /champion/[champName]

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,5 @@
 "use strict";
+var ChampionData = require('../models/championData.js');
 var ChampionRoles = require('../models/championRoles.js');
 var Summaries = require('../models/summaries.js');
 var produceError = require('../logic/produceError.js');
@@ -59,6 +60,13 @@ router.get('/', function(req, res, next) {
             }
         }
     });
+});
+
+router.get('/:champ', function(req, res, next) {
+    var champKey = req.params.champ;
+    if (typeof data.champList[champKey] !== 'undefined') {
+        res.redirect('/champion/' + req.params.champ);
+    }
 });
 
 module.exports = router;


### PR DESCRIPTION
Hi there. I understand if you don't want to put this in, but I've been kind of annoyed at how long it takes to get results from champion.gg from the time I open my browser to the time I get results. Obviously, champ select isn't that long, so quickness is always appreciated. What I've done in the past is just Google (for example) "Ahri counters", but that always leads to one of a number of other counterpick sites, while I prefer champion.gg. :)

Anyways, I've been bemoaning the lack of ability to just go to champion.gg/Ahri to get to Ahri's page, so I just made a little change to allow that. I haven't been able to test it, but I've done tests regarding the base functionality of the thing, and I see no reason why it wouldn't work right out of the box. :)

Thanks for champion.gg!
