### PR TITLE
Fixes width discrepancy of fixedHeader upon filtering

### DIFF
--- a/public/js/statistics_jquery.js
+++ b/public/js/statistics_jquery.js
@@ -40,6 +40,13 @@
         $fixedHeader.css('margin-left','-'+leftOffset+'px');
           
         if($fixedHeader.is(":hidden")){
+          //Fixes discrepancy between fixedHeader and tables width upon filtering or changing sort role. 
+          if($fixedHeader.width() != $table.width()){
+            $fixedHeader.width($table.width());
+              for(var t=0;t<$fixedHeaderTd.length;t++){
+                $fixedHeaderTd.eq(t).width($originalHeaderTd.eq(t).width());
+              }
+          }
           $fixedHeader.show();
         }
       }


### PR DESCRIPTION
Upon filtering or changing the "sort role", the table width can change. Currently, the fixedHeader element only calculates its width based on how the table was initially loaded, causing a discrepancy when it changes due to non-fixed with table columns. 

Note: I didn't use the fixWidths() because the delays aren't needed and makes it look bad upon changing.
