### PR TITLE
Patch 5.22 mastery display changes.

### DIFF
--- a/public/css/master.css
+++ b/public/css/master.css
@@ -39,8 +39,9 @@ body{
 }
 
 .mastery-row{
-  position:relative;
-  left:-2px;
+  display: table;
+  margin-left: auto;
+  margin-right: auto;
 }
 a {
 color: #89f5a2;

--- a/views/champion/masteries.ejs
+++ b/views/champion/masteries.ejs
@@ -5,25 +5,23 @@
       <div class="mastery-header">
         <%= championData.masteries.mostGames.masteries[k].tree %> - <%= championData.masteries.mostGames.masteries[k].total %>
       </div>
-      <br />
       <% for (var z = 1; z<=6; z++){ %>
         <% var masteryColumn = championData.masteries.mostGames.masteries[k].data['row'+z]; %>
         <div class="clearfix mastery-row">
           <% for(var y = 0; y < masteryColumn.length; y++) { %>
-            <% if(masteryColumn[y].mastery){ %>
-              <% if(masteryColumn[y].points){ %>
-                <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %> mastery-active" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>" api-secondary-id="<%- masteryColumn[y].points-1 %>">
-                  <div class="points">
-                    <% for(var p = 0; p < masteryColumn[y].points; p++){ %>
-                      <div class="point"></div>
-                    <% } %>
-                   </div>
-                </div>
-              <% } else { %>
-                <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %>" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>">
-                </div>
-              <% } %>
+            <% if(masteryColumn[y].points){ %>
+              <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %> mastery-active" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>" api-secondary-id="<%- masteryColumn[y].points-1 %>">
+                <div class="points">
+                  <% for(var p = 0; p < masteryColumn[y].points; p++){ %>
+                    <div class="point"></div>
+                  <% } %>
+                 </div>
+              </div>
             <% } else { %>
+              <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %>" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>">
+              </div>
+            <% } %>
+            <% if(z % 2 == 1 && y == 0){ %>
               <div class="mastery-spacer"></div>
             <% } %>
           <% } %>
@@ -44,25 +42,23 @@
       <div class="mastery-header">
         <%= championData.masteries.highestWinPercent.masteries[k].tree %> - <%= championData.masteries.highestWinPercent.masteries[k].total %>
       </div>
-      <br />
       <% for (var z = 1; z<=6; z++){ %>
         <% var masteryColumn = championData.masteries.highestWinPercent.masteries[k].data['row'+z]; %>
         <div class="clearfix mastery-row">
           <% for(var y = 0; y < masteryColumn.length; y++) { %>
-            <% if(masteryColumn[y].mastery){ %>
-              <% if(masteryColumn[y].points){ %>
-                <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %> mastery-active" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>" api-secondary-id="<%- masteryColumn[y].points-1 %>">
-                  <div class="points">
-                    <% for(var p = 0; p < masteryColumn[y].points; p++){ %>
-                      <div class="point"></div>
-                    <% } %>
-                  </div>
-                </div>
-              <% } else { %>
-                <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %>" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>">
-                </div>
-              <% } %>
+            <% if(masteryColumn[y].points){ %>
+              <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %> mastery-active" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>" api-secondary-id="<%- masteryColumn[y].points-1 %>">
+                <div class="points">
+                  <% for(var p = 0; p < masteryColumn[y].points; p++){ %>
+                    <div class="point"></div>
+                  <% } %>
+                 </div>
+              </div>
             <% } else { %>
+              <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %>" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>">
+              </div>
+            <% } %>
+            <% if(z % 2 == 1 && y == 0){ %>
               <div class="mastery-spacer"></div>
             <% } %>
           <% } %>

--- a/views/champion/masteries.ejs
+++ b/views/champion/masteries.ejs
@@ -9,20 +9,22 @@
         <% var masteryColumn = championData.masteries.mostGames.masteries[k].data['row'+z]; %>
         <div class="clearfix mastery-row">
           <% for(var y = 0; y < masteryColumn.length; y++) { %>
-            <% if(masteryColumn[y].points){ %>
-              <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %> mastery-active" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>" api-secondary-id="<%- masteryColumn[y].points-1 %>">
-                <div class="points">
-                  <% for(var p = 0; p < masteryColumn[y].points; p++){ %>
-                    <div class="point"></div>
-                  <% } %>
-                 </div>
-              </div>
-            <% } else { %>
-              <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %>" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>">
-              </div>
-            <% } %>
-            <% if(z % 2 == 1 && y == 0){ %>
-              <div class="mastery-spacer"></div>
+            <% if(masteryColumn[y].mastery){ %>
+              <% if(masteryColumn[y].points){ %>
+                <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %> mastery-active" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>" api-secondary-id="<%- masteryColumn[y].points-1 %>">
+                  <div class="points">
+                    <% for(var p = 0; p < masteryColumn[y].points; p++){ %>
+                      <div class="point"></div>
+                    <% } %>
+                   </div>
+                </div>
+              <% } else { %>
+                <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %>" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>">
+                </div>
+              <% } %>
+              <% if(z % 2 == 1 && y == 0){ %>
+                <div class="mastery-spacer"></div>
+              <% } %>
             <% } %>
           <% } %>
         </div>
@@ -46,20 +48,22 @@
         <% var masteryColumn = championData.masteries.highestWinPercent.masteries[k].data['row'+z]; %>
         <div class="clearfix mastery-row">
           <% for(var y = 0; y < masteryColumn.length; y++) { %>
-            <% if(masteryColumn[y].points){ %>
-              <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %> mastery-active" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>" api-secondary-id="<%- masteryColumn[y].points-1 %>">
-                <div class="points">
-                  <% for(var p = 0; p < masteryColumn[y].points; p++){ %>
-                    <div class="point"></div>
-                  <% } %>
-                 </div>
-              </div>
-            <% } else { %>
-              <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %>" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>">
-              </div>
-            <% } %>
-            <% if(z % 2 == 1 && y == 0){ %>
-              <div class="mastery-spacer"></div>
+            <% if(masteryColumn[y].mastery){ %>
+              <% if(masteryColumn[y].points){ %>
+                <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %> mastery-active" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>" api-secondary-id="<%- masteryColumn[y].points-1 %>">
+                  <div class="points">
+                    <% for(var p = 0; p < masteryColumn[y].points; p++){ %>
+                      <div class="point"></div>
+                    <% } %>
+                   </div>
+                </div>
+              <% } else { %>
+                <div class="mastery-icon mastery-<%= masteryColumn[y].mastery %>" champion-tip api-type="masteries" api-primary-id="<%= masteryColumn[y].mastery %>">
+                </div>
+              <% } %>
+              <% if(z % 2 == 1 && y == 0){ %>
+                <div class="mastery-spacer"></div>
+              <% } %>
             <% } %>
           <% } %>
         </div>


### PR DESCRIPTION
Changes how masteries are displayed for preseason masteries in Patch 5.22 so that every odd numbered row will have an extra spacer between the masteries and 2 will always be displayed on every odd row. Checking for the count will no longer be necessary for any row because alignment will also be changed to centered, so it is not needed.

This all assumes the new mastery sprites are updated. 
