### PR TITLE
CSS adjustments

### DIFF
--- a/public/css/master.css
+++ b/public/css/master.css
@@ -1542,7 +1542,7 @@ color: #FFE08C;
 
 #stats td{
   text-align:center;
-
+  box-sizing: content-box;
 }
 
 #stats tbody td{
@@ -1571,7 +1571,7 @@ border-right: 1px solid rgba(0,0,0,0.21);
 }
 
 #stats div.matchup-champion{
-  transform: scale(0.7);
+  transform: scale(0.75);
 } 
 
 span.stat-champ-title{


### PR DESCRIPTION
Increased size of small champion images from 0.7 scale to 0.75 so it would because 25% reductions scale a lot better than 30% reductions. (however, the scaling isn't really of much value, everything looks fine without it scaled down. 

Also, the box-sizing of "#stats td" was changed to 'content-box'  to eliminate issue where certain long champion names would start on a new line.
