### PR TITLE
Fixing champion table overlap

### DIFF
--- a/public/css/master.css
+++ b/public/css/master.css
@@ -71,7 +71,9 @@ display: none !important;
 }
 
 .table {
+  overflow: hidden;
   table-layout: fixed;
+  width: 100%;
 }
 
 ::-moz-selection { /* Code for Firefox */
@@ -889,7 +891,7 @@ margin: auto;
 
 
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td {
-    padding: 8px;
+    padding: 8px 2px 8px 2px;
     line-height: 1.42857143;
     vertical-align: middle;
     border-top: none;

--- a/views/statistics.ejs
+++ b/views/statistics.ejs
@@ -23,7 +23,7 @@
     <table class="table table-striped" id="table-1" style="table-layout: auto;">
       <thead id="original-header">
         <tr ng-class="{'down':determineOrder('down'),'up':determineOrder('up')}">
-          <td style="width:3%" ng-click="changeOrder()"><span>Rank</span></td>
+          <td style="width:3%" ng-click="changeOrder()"><span>#</span></td>
           <td ng-class="{'selected-column':determineSelected('title')}" style="width:10%;min-width:134px" ng-click="changeSelection('title')"><span>Champion</span></td>
           <td ng-class="{'selected-column':determineSelected('role')}" ng-click="changeSelection('role')"><span>Role</span></td>
           <td ng-class="{'selected-column':determineSelected('winPercent')}" ng-click="changeSelection('winPercent')"><span>Win Percent</span></td>


### PR DESCRIPTION
This is not a full fix, requires some more tweaking but it could possbile fix the champion stats table overlap.

![image](https://cloud.githubusercontent.com/assets/7621705/11555065/b310a19a-999d-11e5-91ea-56a42bc8df19.png)

![image](https://cloud.githubusercontent.com/assets/7621705/11555069/ba7a6bdc-999d-11e5-8f46-a871a6f56c8a.png)
- [ ] Fix champion label.
- [ ] Fix table on scroll
