### PR TITLE
Max size for champion portrait and scaling fix

### DIFF
--- a/public/css/master.css
+++ b/public/css/master.css
@@ -1292,7 +1292,7 @@ margin-right: 6px;
   width:42%;
 }
 .summary-side .matchup-champion {
-  transform: translateZ(0) scale(0.7);
+  transform: translateZ(0) scale(0.75);
   margin-left: -4px
 }
 .summary-side .table .champion-name{
@@ -1573,7 +1573,7 @@ border-right: 1px solid rgba(0,0,0,0.21);
 }
 
 #stats div.matchup-champion{
-  transform: scale(0.75);
+  transform: translateZ(0) scale(0.75);
 } 
 
 span.stat-champ-title{

--- a/public/css/master.css
+++ b/public/css/master.css
@@ -743,6 +743,8 @@ div.champion-area .container-fluid .row{
     display:block;
     margin:auto;
     margin-top:5px;
+    max-width:196px;
+    max-height:196px;
 }
 .champ-index-img{
   border-right: 1px solid rgb(43, 49, 52);
@@ -1290,7 +1292,7 @@ margin-right: 6px;
   width:42%;
 }
 .summary-side .matchup-champion {
-  transform: scale(0.7);
+  transform: translateZ(0) scale(0.7);
   margin-left: -4px
 }
 .summary-side .table .champion-name{


### PR DESCRIPTION
Currently, Wukong's portrait is loading the wrong image from ddragon. As seen here: http://champion.gg/champion/MonkeyKing (as of 6.1.1 patch). 

It's just loading a 1000x1000px green box and because there is no size limit on the site, it's covering the whole page. This change will prevent that from happening again. 

Also for the small champion portraits, added "translateZ(0)" to the transform property to fix the blurriness on Chrome.
