### PR TITLE
Move runes section to bottom when viewport is small.

### DIFF
--- a/views/champion.ejs
+++ b/views/champion.ejs
@@ -36,7 +36,7 @@
               <% include champion/skill_order.ejs %>
             <% } %>
           </div>
-          <div>
+          <div class="hidden-sm hidden-xs">
              <% if (championData.runes.highestWinPercent) { %>
               <% include champion/runes.ejs %>
              <% } %>
@@ -57,6 +57,13 @@
           <div class="row">
             <% if (championData.masteries.mostGames.masteries[0]) { %>
                <% include champion/masteries.ejs %> 
+            <% } %>
+          </div>
+        </div>
+        <div class="col-xs-12 col-sm-12 col-md-6 visible-sm-block visible-xs-block">
+          <div>
+            <% if (championData.runes.highestWinPercent) { %>
+              <% include champion/runes.ejs %>
             <% } %>
           </div>
         </div>


### PR DESCRIPTION
When the viewport is small or extra-small, the runes section would split
the skill order and build order sections. By moving the runes section to
the bottom, we can bring the skill order and build order sections close
together. The runes and masteries are grouped as well now too!

Layout is the same as before when the viewport is medium or larger.

http://imgur.com/a/NQR2S shows what the page now looks like on medium+ and small- viewports.
